### PR TITLE
Fix __main__ import for module execution

### DIFF
--- a/circle_evolution/__main__.py
+++ b/circle_evolution/__main__.py
@@ -1,4 +1,13 @@
-from main import main
+"""Entry point when running ``python -m circle_evolution``.
+
+This module simply re-exports the :func:`main` function from
+``circle_evolution.main``.  The original implementation attempted to import
+``main`` using an absolute import which fails when the package is executed as a
+module.  By using a relative import we ensure the ``main`` module within the
+package is used.
+"""
+
+from .main import main
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `python -m circle_evolution` works by using relative import
- document the purpose of `__main__.py`

## Testing
- `python -m compileall -q circle_evolution`
- `python -m circle_evolution --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840c23f0cb8832cb42754279b9598b4